### PR TITLE
Fix warning in DM.tex.

### DIFF
--- a/assignments/ShapeIndexing/DM.tex
+++ b/assignments/ShapeIndexing/DM.tex
@@ -12,7 +12,7 @@
 
 \usepackage{epsfig}
 \usepackage{setspace}
-\usepackage{fancyheadings}
+\usepackage{fancyhdr}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{graphicx}


### PR DESCRIPTION
LaTeX was showing this warning:

```
fancyheadings: Please stop using fancyheadings! Use fancyhdr instead. We will call fancyhdr with the very same options you passed to fancyheadings.  fancyhdr is 99 percent compatible with fancyheadings. The only incompatibility is that \headrulewidth and \footrulewidth and their \plain... versions are no longer length parameters, but normal macros (to be changed with \renewcommand rather than \setlength)..
```