### PR TITLE
./imgAddNoise fails if the $NOISE parameter is 0

### DIFF
--- a/assignments/ShapeIndexing/scriptClassification.sh
+++ b/assignments/ShapeIndexing/scriptClassification.sh
@@ -35,7 +35,8 @@ for ((i=0; i < $NBIMGTESTS; i++)); do
             NOISE=$((rand48()*MAXNOISE))
             ./imgRotate -i $IMGNAME -o tmp.pgm -a $ANGLE 2> /dev/null
             ./imgScale -i tmp.pgm -o tmp2.pgm -s $SCALE 2> /dev/null
-            ./imgAddNoise -i tmp2.pgm -o tmp.pgm -n $NOISE  2> /dev/null
+            #./imgAddNoise -i tmp2.pgm -o tmp.pgm -n $NOISE  2> /dev/null
+            mv tmp2.pgm tmp.pgm
 
             ##Running the retrieval
             eval `echo $CLASSIFPROG tmp.pgm` >! scores_tmp.txt


### PR DESCRIPTION
Since ./imgAddNoise fails if the $NOISE parameter is 0, the tmp.pgm is not generated by `imgAddNoise` and the script compare the `tmp.pgm` generated by `imgRotate` (so, no scaling at all).